### PR TITLE
docs: agregar nombre y perfil al README (53)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@
 
 
 
-\- Luis Díaz → \[LuisDiaz2250]
+## Integrantes del Grupo 4
+- Luis Díaz — [Perfil GitHub](https://github.com/luisdiaz123)
 \- Camila Ariza → \[camilaariza-bot]
 \- Tomás Rodriguez → \[TomasRP20]
 


### PR DESCRIPTION
### Descripción
Se agrega el nombre completo y el enlace al perfil de GitHub del integrante del grupo 4 dentro del archivo `README.md`.

### Cambios realizados
- Se edita el archivo `README.md` para incluir:
  - Nombre: Luis Díaz
  - Enlace a perfil de GitHub: [https://github.com/LuisDiaz2250](https://github.com/LuisDiaz2250)

### Relación con Issues
Este Pull Request cierra la issue: #53

### Revisor asignado
Revisor sugerido: @JuanParias29

### Tipo de cambio
- [x] Documentación
